### PR TITLE
Please make the output reproducible

### DIFF
--- a/bin/preamble
+++ b/bin/preamble
@@ -3,12 +3,17 @@
 var os = require("os"),
     fs = require("fs");
 
+var now = new Date();
+if (process.env.SOURCE_DATE_EPOCH) {
+  now = new Date((process.env.SOURCE_DATE_EPOCH * 1000) + (now.getTimezoneOffset() * 60000));
+}
+
 fs.readFile("package.json", "utf8", function(error, text) {
   if (error) throw error;
   var json = JSON.parse(text);
   process.stdout.write("// " + (json.homepage || json.name)
       + " Version " + json.version + "."
-      + " Copyright " + (new Date).getFullYear()
+      + " Copyright " + now.getFullYear()
       + " " + json.author.name + (/\.$/.test(json.author.name) ? "" : ".")
       + os.EOL);
 });


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that node-package-preamble generates output that is not
reproducible which is affecting the reproducibility of (at least)
5 packages in Debian.

This patch alters preamble to use SOURCE_DATE_EPOCH [1].

This was originally filed as #892425 [2].

 [0] https://reproducible-builds.org/
 [1] https://reproducible-builds.org/specs/source-date-epoch/
 [2] https://bugs.debian.org/892425

Signed-off-by: Chris Lamb <lamby@debian.org>